### PR TITLE
Adding proposed endpoints section with suggestions for reportback endpoints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ URL | HTTP Verb | Functionality
 
 URL | HTTP Verb | Functionality
 --- | --------- | -----------
-`/users/:nid/reportbacks`                       | GET | For a specific user, retrieve all reportback *files*
-`/users/:nid/reportbacks/:rbid`                 | GET | For a specific user, retrieve all reportback *files* for a specific reportback
-`/users/:nid/reportbacks/:rbid?status=promoted` | GET | For a specific user, retrieve all reportback *files* for a specific reportback filtered by parameters
+`/users/:uid/reportbacks`                       | GET | For a specific user, retrieve all reportback *files*
+`/users/:uid/reportbacks/:rbid`                 | GET | For a specific user, retrieve all reportback *files* for a specific reportback
+`/users/:uid/reportbacks/:rbid?status=promoted` | GET | For a specific user, retrieve all reportback *files* for a specific reportback filtered by parameters
 
 
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ URL | HTTP Verb | Functionality
 `/campaigns/:nid/reportback`         | PUT   | [Updating a Campaign Report Back](https://github.com/DoSomething/northstar/wiki/Spec#updating-a-campaign-report-back)
 `/keys`                              | POST  | Generate new api key
 
+
 ### Drupal Enpoints
 
 `https://www.dosomething.org/api/v1`
@@ -31,11 +32,11 @@ URL | HTTP Verb | Functionality
 `/auth/logout`                   | POST | [Logging out](https://github.com/DoSomething/dosomething/wiki/API#user-logout)
 `/auth/token`                    | POST | [Retrieve the X-CSRF Token for the logged in user](https://github.com/DoSomething/dosomething/wiki/API#get-authentication-token)
 `/content/:nid`                  | GET  | [Retrieve a campaign](https://github.com/DoSomething/dosomething/wiki/API#retrieve-a-campaign)
-`campaigns`                      | GET  | [Retrieve all active campaigns](https://github.com/DoSomething/dosomething/wiki/API#retrieve-all-active-campaigns)
-`campaigns/[nid]/signup`         | POST | [Creates a User Signup for the given Campaign nid](https://github.com/DoSomething/dosomething/wiki/API#campaign-signup)
-`campaigns/[nid]/reportback`     | POST | [Creates or updates a User Reportback for the given Campaign nid](https://github.com/DoSomething/dosomething/wiki/API#campaign-reportback)
-`/campaigns/[nid]/gallery`       | GET  | [Retrieves approved Reportback Files for the given Campaign nid](https://github.com/DoSomething/dosomething/wiki/API#campaign-gallery)
-`reportback_files/[fid]/review`  | POST | [Review a Reportback File](https://github.com/DoSomething/dosomething/wiki/API#review-a-reportback-file)
+`/campaigns`                     | GET  | [Retrieve all active campaigns](https://github.com/DoSomething/dosomething/wiki/API#retrieve-all-active-campaigns)
+`/campaigns/:nid/signup`         | POST | [Creates a User Signup for the given Campaign nid](https://github.com/DoSomething/dosomething/wiki/API#campaign-signup)
+`/campaigns/:nid/reportback`     | POST | [Creates or updates a User Reportback for the given Campaign nid](https://github.com/DoSomething/dosomething/wiki/API#campaign-reportback)
+`/campaigns/:nid/gallery`        | GET  | [Retrieves approved Reportback Files for the given Campaign nid](https://github.com/DoSomething/dosomething/wiki/API#campaign-gallery)
+`/reportback_files/:fid:/review` | POST | [Review a Reportback File](https://github.com/DoSomething/dosomething/wiki/API#review-a-reportback-file)
 `/system/connect`                | POST | [Retrieves session info for a user](https://github.com/DoSomething/dosomething/wiki/API#connection-status)
 `/system/set_variable`           | POST | [Set a system variable](https://github.com/DoSomething/dosomething/wiki/API#set-a-variable)
 `/users`                         | GET  | [Get a user](https://github.com/DoSomething/dosomething/wiki/API#find-a-user)
@@ -43,7 +44,39 @@ URL | HTTP Verb | Functionality
 `/users/get_member_count`        | POST | [Retrieve member count](https://github.com/DoSomething/dosomething/wiki/API#get-member-count)
  
 
+***
+
+## Proposed Endpoints
+
+### Drupal Endpoints (suggested)
+
+URL | HTTP Verb | Functionality
+--- | --------- | -----------
+`/reportbacks`                                              | GET | Retrieve all reportbacks
+`/reportbacks/:rbid`                                        | GET | Retrieve a specific reportback
+`/reportbacks/campaign/:nid`                                | GET | Retrieve all reportbacks for a specific campaign
+`/reportbacks/campaign/:nid?status=promoted,approved`       | GET | Retrieve all reportbacks for a specific campaign filtered by parameters
+`/reportbacks/campaign?nids=:nid,:nid,:nid`                 | GET | Retrieve all reportbacks for multiple specified campaigns
+`/reportbacks/campaign?nids=:nid,:nid,:nid&status=approved` | GET | Retrieve all reportbacks for multiple specified campaigns filtered by parameters
+
+
+URL | HTTP Verb | Functionality
+--- | --------- | -----------
+`/campaigns/:nid/reportbacks`                          | GET | For a specific campaign, retrieve all reportbacks
+`/campaigns/:nid/reportbacks/:rbid`                    | GET | For a specific campaign, retrieve a specific reportback
+`/campaigns/:nid/reportbacks?status=promoted,approved` | GET | For a specific campaign, retrieve all reportbacks filtered by parameters
+
+
+URL | HTTP Verb | Functionality
+--- | --------- | -----------
+`/users/:nid/reportbacks`                       | GET | For a specific user, retrieve all reportback *files*
+`/users/:nid/reportbacks/:rbid`                 | GET | For a specific user, retrieve all reportback *files* for a specific reportback
+`/users/:nid/reportbacks/:rbid?status=promoted` | GET | For a specific user, retrieve all reportback *files* for a specific reportback filtered by parameters
 
 
 
-`
+
+
+
+
+


### PR DESCRIPTION
So I propose that there's a basic assumption we should make. 

When retrieving Reportbacks, whether a general index collection or for a specific campaign we'll always (typically) want to retrieve the _latest_ reportbacks for all our users and NOT a user's multiple reportbacks. 

Instead, we always use the `/users/:uid/reportbacks` endpoint when we want to retrieve all the reportback **files** for a specific user. Typically we won't want/need to retrieve all reportback files unless we're dealing with data for a specific user (for example on the profile page, or reportback form on the user campaign action page).

For a campaign action page we'd thus hit 2 endpoints:
- `/users/:uid/reportbacks/:rbid` to get the user's latest Reportback as well as all other prior reportbacks for that campaign.
- `/reportbacks/campaign/:nid?status=promoted,approved` or `/campaigns/:nid/reportbacks?status=promoted,approved` to get all the _promoted_ and _approved_ reportbacks for a specific campaign for use in the reportback gallery.

Plus, if we want to retrieve all reportback files without specifying a user on the `/reportback` endpoint, it could just be an additional parameter we pass. As a quick example:

```
/reportbacks?gottacatchemall=true
/reportbacks/:rbid?gottacatchemall=true
/reportbacks/campaign/:nid?gottacatchemall=true
```

![download-4](https://cloud.githubusercontent.com/assets/105849/6531148/da61fc9a-c404-11e4-87cb-c7c6d66d7d43.jpg)

@aaronschachter @angaither @jonuy 
